### PR TITLE
Astro PWA: migração Quasar → Cloudflare Workers

### DIFF
--- a/frontend/.dev.vars.example
+++ b/frontend/.dev.vars.example
@@ -1,4 +1,5 @@
 # Local development secrets (copy to .dev.vars)
+# Public values can also live in wrangler.toml [vars]; keep secrets here locally.
 AUTH_SECRET=change-me-in-production
 BETTER_AUTH_URL=http://localhost:4321
 COGNITO_CLIENT_ID=
@@ -7,6 +8,12 @@ COGNITO_DOMAIN=
 COGNITO_USER_POOL_ID=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-AWS_REGION=us-east-1
+AWS_REGION=sa-east-1
 SES_FROM_EMAIL=
 SNS_PLATFORM_ARN=
+
+# Production secrets (Workers):
+# wrangler secret put AUTH_SECRET
+# wrangler secret put COGNITO_CLIENT_SECRET
+# wrangler secret put AWS_ACCESS_KEY_ID
+# wrangler secret put AWS_SECRET_ACCESS_KEY

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -21,6 +21,7 @@
   "login_terms": "By signing in you accept the terms and conditions",
   "login_error_account_not_linked": "We couldn't link this social account to your existing account. Try signing in with the method you used before, or use the same email across providers.",
   "login_error_oauth_generic": "Sign-in could not be completed. Please try again or use another sign-in method.",
+  "login_error_oauth_config_missing": "Sign-in is temporarily unavailable: server authentication is not fully configured.",
   "terms_title": "Terms and Conditions",
   "terms_updated": "Last updated: June 2026",
   "header_greeting": "Hi, {name}",

--- a/frontend/src/i18n/es-ES.json
+++ b/frontend/src/i18n/es-ES.json
@@ -21,6 +21,7 @@
   "login_terms": "Al entrar el usuario acepta los términos y condiciones",
   "login_error_account_not_linked": "No se pudo vincular esta cuenta social a tu cuenta existente. Intenta entrar con el método que usaste antes o usa el mismo correo en todos los proveedores.",
   "login_error_oauth_generic": "No se pudo completar el inicio de sesión. Inténtalo de nuevo o usa otro método de acceso.",
+  "login_error_oauth_config_missing": "Inicio de sesión no disponible: la autenticación del servidor no está completamente configurada.",
   "terms_title": "Términos y Condiciones",
   "terms_updated": "Última actualización: junio de 2026",
   "header_greeting": "Hola, {name}",

--- a/frontend/src/i18n/pt-BR.json
+++ b/frontend/src/i18n/pt-BR.json
@@ -21,6 +21,7 @@
   "login_terms": "Ao entrar o usuário aceita os termos e condições",
   "login_error_account_not_linked": "Não foi possível vincular esta conta social à sua conta existente. Tente entrar com o método que você usou antes ou use o mesmo e-mail em todos os provedores.",
   "login_error_oauth_generic": "Não foi possível concluir o login. Tente novamente ou use outro método de entrada.",
+  "login_error_oauth_config_missing": "Login indisponível no momento: configuração de autenticação incompleta no servidor.",
   "terms_title": "Termos e Condições",
   "terms_updated": "Última atualização: junho de 2026",
   "header_greeting": "Olá, {name}",

--- a/frontend/src/lib/auth-config.ts
+++ b/frontend/src/lib/auth-config.ts
@@ -1,0 +1,64 @@
+import { env } from 'cloudflare:workers';
+
+const COGNITO_ENV_KEYS = ['COGNITO_DOMAIN', 'COGNITO_CLIENT_ID', 'COGNITO_CLIENT_SECRET'] as const;
+
+export class AuthConfigError extends Error {
+	constructor(missing: string[]) {
+		super(
+			`Missing auth environment variable(s): ${missing.join(', ')}. ` +
+				'Set public values in wrangler.toml [vars] and secrets with `wrangler secret put`.',
+		);
+		this.name = 'AuthConfigError';
+	}
+}
+
+export function normalizeCognitoDomain(domain: string): string {
+	return domain.replace(/^https?:\/\//, '').replace(/\/$/, '');
+}
+
+export function isCognitoOAuthConfigured(): boolean {
+	return COGNITO_ENV_KEYS.every((key) => Boolean(env[key]));
+}
+
+export function getMissingCognitoEnvKeys(): string[] {
+	return COGNITO_ENV_KEYS.filter((key) => !env[key]);
+}
+
+export function requireCognitoOAuthConfig(): {
+	domain: string;
+	clientId: string;
+	clientSecret: string;
+} {
+	const missing = getMissingCognitoEnvKeys();
+	if (missing.length > 0) {
+		throw new AuthConfigError([...missing]);
+	}
+
+	return {
+		domain: normalizeCognitoDomain(env.COGNITO_DOMAIN!),
+		clientId: env.COGNITO_CLIENT_ID!,
+		clientSecret: env.COGNITO_CLIENT_SECRET!,
+	};
+}
+
+export function requireAuthSecret(): string {
+	if (!env.AUTH_SECRET) {
+		throw new AuthConfigError(['AUTH_SECRET']);
+	}
+	return env.AUTH_SECRET;
+}
+
+export function authBaseUrl(): string {
+	return env.BETTER_AUTH_URL ?? env.SITE_URL ?? 'http://localhost:4321';
+}
+
+export function authTrustedOrigins(): string[] {
+	const origins = new Set([
+		authBaseUrl(),
+		env.SITE_URL,
+		'http://localhost:4321',
+		'https://52weekchallenge.app',
+	].filter(Boolean) as string[]);
+
+	return [...origins];
+}

--- a/frontend/src/lib/better-auth.ts
+++ b/frontend/src/lib/better-auth.ts
@@ -2,6 +2,13 @@ import { betterAuth } from 'better-auth';
 import { genericOAuth } from 'better-auth/plugins';
 import { env } from 'cloudflare:workers';
 import { syncF2wUserFromBetterAuth } from './user-sync';
+import {
+	authBaseUrl,
+	authTrustedOrigins,
+	isCognitoOAuthConfigured,
+	requireAuthSecret,
+	requireCognitoOAuthConfig,
+} from './auth-config';
 
 const COGNITO_IDPS = {
 	'cognito-google': 'Google',
@@ -14,17 +21,14 @@ const COGNITO_OAUTH_PROVIDER_IDS_LIST = [
 	'cognito-facebook',
 ] as const;
 
-function authBaseUrl(): string {
-	return env.BETTER_AUTH_URL ?? env.SITE_URL ?? 'http://localhost:4321';
-}
-
 function cognitoOAuthConfig(providerId: keyof typeof COGNITO_IDPS) {
-	const domain = env.COGNITO_DOMAIN.replace(/^https?:\/\//, '');
+	const { domain, clientId, clientSecret } = requireCognitoOAuthConfig();
 	const base = `https://${domain}`;
+
 	return {
 		providerId,
-		clientId: env.COGNITO_CLIENT_ID,
-		clientSecret: env.COGNITO_CLIENT_SECRET,
+		clientId,
+		clientSecret,
 		authorizationUrl: `${base}/oauth2/authorize`,
 		tokenUrl: `${base}/oauth2/token`,
 		userInfoUrl: `${base}/oauth2/userinfo`,
@@ -49,13 +53,17 @@ function cognitoOAuthConfig(providerId: keyof typeof COGNITO_IDPS) {
 	};
 }
 
+let authInstance: ReturnType<typeof betterAuth> | null = null;
+
 export function createAuth() {
+	if (authInstance) return authInstance;
+
 	const baseURL = authBaseUrl();
 
-	return betterAuth({
-		secret: env.AUTH_SECRET,
+	authInstance = betterAuth({
+		secret: requireAuthSecret(),
 		baseURL,
-		trustedOrigins: [baseURL, 'http://localhost:4321', 'https://52weekchallenge.app'],
+		trustedOrigins: authTrustedOrigins(),
 		database: env.DB,
 		user: {
 			modelName: 'f2w_ba_user',
@@ -116,14 +124,16 @@ export function createAuth() {
 		advanced: {
 			cookiePrefix: 'f2w',
 		},
-		plugins: [
-			genericOAuth({
-				config: [
-					cognitoOAuthConfig('cognito-google'),
-					cognitoOAuthConfig('cognito-facebook'),
-				],
-			}),
-		],
+		plugins: isCognitoOAuthConfigured()
+			? [
+					genericOAuth({
+						config: [
+							cognitoOAuthConfig('cognito-google'),
+							cognitoOAuthConfig('cognito-facebook'),
+						],
+					}),
+				]
+			: [],
 		databaseHooks: {
 			session: {
 				create: {
@@ -154,6 +164,8 @@ export function createAuth() {
 			},
 		},
 	});
+
+	return authInstance;
 }
 
 export const COGNITO_OAUTH_PROVIDER_IDS = {
@@ -162,3 +174,5 @@ export const COGNITO_OAUTH_PROVIDER_IDS = {
 } as const;
 
 export type CognitoLoginProvider = keyof typeof COGNITO_OAUTH_PROVIDER_IDS;
+
+export { isCognitoOAuthConfigured } from './auth-config';

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,5 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 import { env } from 'cloudflare:workers';
+import { AuthConfigError } from './lib/auth-config';
 import { createAuth } from './lib/better-auth';
 import { getF2wUserByEmail } from './lib/user-sync';
 import { getLocaleFromCookie } from './i18n';
@@ -7,10 +8,19 @@ import { getLocaleFromCookie } from './i18n';
 export const onRequest = defineMiddleware(async (context, next) => {
 	context.locals.locale = getLocaleFromCookie(context.request.headers.get('cookie') ?? '');
 
-	const session = await createAuth().api.getSession({ headers: context.request.headers });
-	context.locals.user = session?.user?.email
-		? await getF2wUserByEmail(env.DB, session.user.email)
-		: null;
+	try {
+		const session = await createAuth().api.getSession({ headers: context.request.headers });
+		context.locals.user = session?.user?.email
+			? await getF2wUserByEmail(env.DB, session.user.email)
+			: null;
+	} catch (err) {
+		if (err instanceof AuthConfigError) {
+			console.error('[auth]', err.message);
+			context.locals.user = null;
+		} else {
+			throw err;
+		}
+	}
 
 	return next();
 });

--- a/frontend/src/pages/api/auth/login/[provider].ts
+++ b/frontend/src/pages/api/auth/login/[provider].ts
@@ -1,5 +1,10 @@
 import type { APIRoute } from 'astro';
-import { createAuth, COGNITO_OAUTH_PROVIDER_IDS, type CognitoLoginProvider } from '@/lib/better-auth';
+import {
+	createAuth,
+	COGNITO_OAUTH_PROVIDER_IDS,
+	isCognitoOAuthConfigured,
+	type CognitoLoginProvider,
+} from '@/lib/better-auth';
 
 const IDP_KEYS: Record<string, CognitoLoginProvider> = {
 	google: 'google',
@@ -7,6 +12,11 @@ const IDP_KEYS: Record<string, CognitoLoginProvider> = {
 };
 
 export const GET: APIRoute = async ({ params, request }) => {
+	if (!isCognitoOAuthConfigured()) {
+		console.error('[auth] OAuth login unavailable: missing Cognito environment variables');
+		return Response.redirect('/login?error=oauth_config_missing', 302);
+	}
+
 	const key = params.provider ?? '';
 	const providerKey = IDP_KEYS[key];
 

--- a/frontend/src/pages/login.astro
+++ b/frontend/src/pages/login.astro
@@ -13,9 +13,11 @@ const oauthError = Astro.url.searchParams.get('error');
 const loginErrorMessage =
 	oauthError === 'account_not_linked'
 		? dict.login_error_account_not_linked
-		: oauthError
-			? dict.login_error_oauth_generic
-			: null;
+		: oauthError === 'oauth_config_missing'
+			? dict.login_error_oauth_config_missing
+			: oauthError
+				? dict.login_error_oauth_generic
+				: null;
 ---
 
 <BaseLayout title={dict.login_title}>

--- a/frontend/upload-dev-secrets.sh
+++ b/frontend/upload-dev-secrets.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV_VARS_FILE="${SCRIPT_DIR}/.dev.vars"
+WRANGLER_CONFIG_FILE="${SCRIPT_DIR}/wrangler.toml"
+TARGET_ENV=""
+WORKER_NAME=""
+
+usage() {
+  cat <<'EOF'
+Uso:
+  bash ./upload-dev-secrets.sh [--env <ambiente>] [--file <arquivo>] [--name <worker>] [--config <arquivo>]
+
+Exemplos:
+  bash ./upload-dev-secrets.sh
+  bash ./upload-dev-secrets.sh --env dev
+  bash ./upload-dev-secrets.sh --env production --file .dev.vars
+  bash ./upload-dev-secrets.sh --name feliz-natal
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -e|--env)
+      [[ $# -lt 2 ]] && { echo "Erro: faltou valor para $1."; usage; exit 1; }
+      TARGET_ENV="$2"
+      shift 2
+      ;;
+    -f|--file)
+      [[ $# -lt 2 ]] && { echo "Erro: faltou valor para $1."; usage; exit 1; }
+      DEV_VARS_FILE="$2"
+      if [[ "${DEV_VARS_FILE}" != /* ]]; then
+        DEV_VARS_FILE="${SCRIPT_DIR}/${DEV_VARS_FILE}"
+      fi
+      shift 2
+      ;;
+    -c|--config)
+      [[ $# -lt 2 ]] && { echo "Erro: faltou valor para $1."; usage; exit 1; }
+      WRANGLER_CONFIG_FILE="$2"
+      if [[ "${WRANGLER_CONFIG_FILE}" != /* ]]; then
+        WRANGLER_CONFIG_FILE="${SCRIPT_DIR}/${WRANGLER_CONFIG_FILE}"
+      fi
+      shift 2
+      ;;
+    -n|--name)
+      [[ $# -lt 2 ]] && { echo "Erro: faltou valor para $1."; usage; exit 1; }
+      WORKER_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Erro: argumento desconhecido: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v wrangler >/dev/null 2>&1; then
+  echo "Erro: wrangler nao encontrado no PATH."
+  exit 1
+fi
+
+if [[ ! -f "${DEV_VARS_FILE}" ]]; then
+  echo "Erro: arquivo de variaveis nao encontrado em ${DEV_VARS_FILE}."
+  exit 1
+fi
+
+if [[ ! -f "${WRANGLER_CONFIG_FILE}" ]]; then
+  echo "Erro: arquivo de configuracao do wrangler nao encontrado em ${WRANGLER_CONFIG_FILE}."
+  exit 1
+fi
+
+if [[ -z "${WORKER_NAME}" ]]; then
+  WORKER_NAME="$(
+    awk -F= '
+      /^[[:space:]]*name[[:space:]]*=/ {
+        value=$2
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+        gsub(/^"/, "", value)
+        gsub(/"$/, "", value)
+        print value
+        exit
+      }
+    ' "${WRANGLER_CONFIG_FILE}"
+  )"
+fi
+
+if [[ -z "${WORKER_NAME}" ]]; then
+  echo "Erro: nao foi possivel identificar o nome do worker. Use --name <worker>."
+  exit 1
+fi
+
+is_non_secret_key() {
+  case "$1" in
+    PUBLIC_*) return 0 ;;
+    AWS_REGION|AWS_ACCOUNT_ID|USER_POOL_NAME|CALLBACK_URLS|LOGOUT_URLS) return 0 ;;
+    GOOGLE_CLIENT_ID|MICROSOFT_CLIENT_ID|MICROSOFT_TENANT_ID|SLACK_CLIENT_ID|FACEBOOK_LOGIN_APP_ID) return 0 ;;
+    DATABASE_URL|WEBSOCKET_WORKER_URL|AVATAR_PUBLIC_BASE_URL) return 0 ;;
+    WHATSAPP_PHONE_NUMBER_ID|WHATSAPP_INVITE_TEMPLATE_NAME|WHATSAPP_INVITE_TEMPLATE_LANG|WHATSAPP_API_VERSION|WHATSAPP_INVITE_TEMPLATE_COMPONENTS|WHATSAPP_INVITE_USE_NAMED_PARAMETERS|WHATSAPP_INVITE_INCLUDE_HEADER|WHATSAPP_INVITE_INCLUDE_BUTTON|WHATSAPP_SITE_BASE_URL|WHATSAPP_HEADER_IMAGE_URL|WHATSAPP_DEFAULT_COUNTRY_CODE) return 0 ;;
+    SES_FROM_EMAIL|SES_FROM_NAME) return 0 ;;
+  esac
+
+  return 1
+}
+
+trim_quotes() {
+  local value="$1"
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "${value}"
+}
+
+uploaded=0
+skipped=0
+wrangler_args=(--name "${WORKER_NAME}" --config "${WRANGLER_CONFIG_FILE}")
+if [[ -n "${TARGET_ENV}" ]]; then
+  wrangler_args+=(--env "${TARGET_ENV}")
+fi
+
+while IFS= read -r raw_line || [[ -n "${raw_line}" ]]; do
+  line="${raw_line#"${raw_line%%[![:space:]]*}"}"
+
+  [[ -z "${line}" ]] && continue
+  [[ "${line}" == \#* ]] && continue
+  [[ "${line}" != *=* ]] && continue
+
+  key="${line%%=*}"
+  value="${line#*=}"
+
+  key="${key%"${key##*[![:space:]]}"}"
+  value="${value#"${value%%[![:space:]]*}"}"
+
+  [[ -z "${key}" ]] && continue
+  [[ -z "${value}" ]] && continue
+
+  if is_non_secret_key "${key}"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  value="$(trim_quotes "${value}")"
+
+  if [[ -n "${TARGET_ENV}" ]]; then
+    echo "-> enviando segredo: ${key} (worker: ${WORKER_NAME}, env: ${TARGET_ENV})"
+  else
+    echo "-> enviando segredo: ${key} (worker: ${WORKER_NAME}, env: default)"
+  fi
+  printf '%s' "${value}" | wrangler secret put "${key}" "${wrangler_args[@]}"
+  uploaded=$((uploaded + 1))
+done < "${DEV_VARS_FILE}"
+
+echo
+echo "Concluido. Segredos enviados: ${uploaded}. Variaveis ignoradas: ${skipped}."

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,4 +1,4 @@
-name = "f2w-frontend"
+name = "52weeks"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 
@@ -24,3 +24,12 @@ id = "00ca0b8ef45143f6aede0d5dd2d32e65"
 
 [vars]
 SITE_URL = "https://52weekchallenge.app"
+BETTER_AUTH_URL = "https://52weeks.amb1.workers.dev"
+COGNITO_DOMAIN = "sa-east-1qss34qx4b.auth.sa-east-1.amazoncognito.com"
+COGNITO_USER_POOL_ID = "sa-east-1_qSS34qX4b"
+COGNITO_CLIENT_ID = "21kjqv2t7i3j3fe38eqngl4bsi"
+AWS_REGION = "sa-east-1"
+SES_FROM_EMAIL = "domains@ambiente1.com.br"
+
+# Secrets (set in production with `wrangler secret put <NAME>`):
+# AUTH_SECRET, COGNITO_CLIENT_SECRET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, SNS_PLATFORM_ARN


### PR DESCRIPTION
## Summary
- Substitui o app Quasar legado por frontend Astro 6 (PWA) em Cloudflare Workers com D1, Better Auth + Cognito (Google/Facebook), depósitos assíncronos via JSON, htmx para notificações e Lottie na splash/welcome.
- Corrige erro de produção `COGNITO_DOMAIN.replace` com validação de env, vars públicas no `wrangler.toml` e script `upload-dev-secrets.sh` para secrets do Worker.
- Inclui worker de monitoring, migrations D1 e account linking entre provedores sociais.

## Test plan
- [ ] `cd frontend && npm run build`
- [ ] Login Google e Facebook em local com `.dev.vars`
- [ ] Swipe de depósito atualiza timeline sem reload e dispara confetti
- [ ] Deploy em Workers com secrets configurados (`AUTH_SECRET`, `COGNITO_CLIENT_SECRET`, etc.)
- [ ] `npm run db:migrate:remote` na D1 de produção
- [ ] Verificar splash com `wallet.lottie` e redirect para `/welcome`


Made with [Cursor](https://cursor.com)