### PR TITLE
Goal submit loading state on create

### DIFF
--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -15,6 +15,7 @@
   "goal_checkbox_deadline": "Choose a deadline for the goal",
   "goal_change_date": "Change date",
   "goal_submit": "Register goal",
+  "goal_submitting": "Creating goal",
   "login_title": "Now just create an account and start reaching your goal",
   "login_subtitle": "Choose a sign-in method below and access your goal",
   "login_google": "Continue with Google",

--- a/frontend/src/i18n/es-ES.json
+++ b/frontend/src/i18n/es-ES.json
@@ -15,6 +15,7 @@
   "goal_checkbox_deadline": "Elegir una fecha límite para el objetivo",
   "goal_change_date": "Cambiar fecha",
   "goal_submit": "Registrar objetivo",
+  "goal_submitting": "Creando objetivo",
   "login_title": "Ahora solo falta crear una cuenta y empezar a alcanzar tu objetivo",
   "login_subtitle": "Selecciona una forma de entrar abajo y accede a tu objetivo",
   "login_google": "Continuar con Google",

--- a/frontend/src/i18n/pt-BR.json
+++ b/frontend/src/i18n/pt-BR.json
@@ -15,6 +15,7 @@
   "goal_checkbox_deadline": "Escolher uma data limite para o objetivo",
   "goal_change_date": "Alterar a data",
   "goal_submit": "Cadastrar objetivo",
+  "goal_submitting": "Criando objetivo",
   "login_title": "Agora só falta criar uma conta e começar a atingir seu objetivo",
   "login_subtitle": "Selecione uma forma de entrar abaixo e acesse o seu objetivo",
   "login_google": "Continuar com Google",

--- a/frontend/src/pages/goals/new.astro
+++ b/frontend/src/pages/goals/new.astro
@@ -125,8 +125,30 @@ const isLoggedIn = !!Astro.locals.user;
 			</div>
 		</div>
 
-		<button type="button" class="btn-primary mt-10" @click="submit()">
-			{dict.goal_submit}
+		<button
+			type="button"
+			class="btn-primary mt-10 inline-flex w-full items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-70"
+			:disabled="submitting"
+			@click="submit()"
+		>
+			<svg
+				x-show="submitting"
+				x-cloak
+				class="h-5 w-5 shrink-0 animate-spin"
+				xmlns="http://www.w3.org/2000/svg"
+				fill="none"
+				viewBox="0 0 24 24"
+				aria-hidden="true"
+			>
+				<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+				<path
+					class="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+				></path>
+			</svg>
+			<span x-show="!submitting">{dict.goal_submit}</span>
+			<span x-show="submitting" x-cloak>{dict.goal_submitting}</span>
 		</button>
 	</div>
 
@@ -143,6 +165,7 @@ const isLoggedIn = !!Astro.locals.user;
 				deadlineDate: '',
 				showDateModal: false,
 				showErrors: false,
+				submitting: false,
 				isLoggedIn: config.isLoggedIn,
 				minDate: new Date(Date.now() + 86400000).toISOString().slice(0, 10),
 
@@ -252,6 +275,8 @@ const isLoggedIn = !!Astro.locals.user;
 				},
 
 				async submit() {
+					if (this.submitting) return;
+
 					if (!this.canSubmit) {
 						this.showErrors = true;
 						if (this.useDeadline && (!this.deadlineDate || this.deadlineDate <= this.minDate)) {
@@ -271,16 +296,19 @@ const isLoggedIn = !!Astro.locals.user;
 					window.f2wSync?.saveDraftGoal(draft);
 
 					if (this.isLoggedIn) {
-						window.f2wGoals?.createGoalOptimistically(
+						this.submitting = true;
+						const ok = await window.f2wGoals?.createGoalOptimistically(
 							draft,
 							config.locale,
 							config.dict.goal_create_error,
 							config.dict.goal_progress,
 							config.dict.goal_created_at,
 						);
-					} else {
-						window.location.href = '/login';
+						if (!ok) this.submitting = false;
+						return;
 					}
+
+					window.location.href = '/login';
 				},
 			}));
 

--- a/frontend/src/scripts/goals-optimistic.ts
+++ b/frontend/src/scripts/goals-optimistic.ts
@@ -1,6 +1,7 @@
 import { getCache, setCache, removeCache } from './sync-client';
 import {
 	saveSnapshot,
+	runOptimisticMutation,
 	runOptimisticMutationKeepalive,
 	clearSnapshot,
 } from './optimistic-client';
@@ -296,13 +297,13 @@ export function hydrateGoalsList(): void {
 	bindGoalCardPrefetchAll(list);
 }
 
-export function createGoalOptimistically(
+export async function createGoalOptimistically(
 	draft: DraftPayload,
 	locale: string,
 	errorMessage: string,
 	progressLabel: string,
 	createdAtTemplate: string,
-): void {
+): Promise<boolean> {
 	const tempId = crypto.randomUUID();
 	const pending: PendingGoal = {
 		id: tempId,
@@ -320,7 +321,7 @@ export function createGoalOptimistically(
 	const storageKey = `goals:create:${tempId}`;
 	saveSnapshot(storageKey, pending);
 
-	runOptimisticMutationKeepalive<{ goal: Goal }>({
+	const ok = await runOptimisticMutation<{ goal: Goal }>({
 		storageKey,
 		rollback: () => {
 			removePendingGoal(tempId);
@@ -331,23 +332,20 @@ export function createGoalOptimistically(
 			method: 'POST',
 			body: JSON.stringify(draft),
 		},
-		onSuccess: (data) => {
-			const existing = document.querySelector<HTMLElement>(`[data-goal-card="${tempId}"]`);
+		onSuccess: () => {
 			removePendingGoal(tempId);
 			clearSnapshot(storageKey);
 			invalidateGoalsListCache();
-			if (existing) {
-				existing.replaceWith(
-					renderGoalCard(data.goal, locale, progressLabel, createdAtTemplate),
-				);
-			}
 		},
 		errorMessage,
 	});
 
+	if (!ok) return false;
+
 	window.f2wSync?.clearDraftGoal();
 	document.documentElement.dataset.transition = 'forward';
 	window.location.href = '/goals';
+	return true;
 }
 
 export function deleteGoalOptimistically(goalId: string, deleteUrl: string, errorMessage: string): void {

--- a/frontend/src/scripts/optimistic-client.ts
+++ b/frontend/src/scripts/optimistic-client.ts
@@ -33,7 +33,9 @@ export interface OptimisticMutationOptions<T = unknown> {
 	errorMessage?: string;
 }
 
-export async function runOptimisticMutation<T = unknown>(opts: OptimisticMutationOptions<T>): Promise<void> {
+export async function runOptimisticMutation<T = unknown>(
+	opts: OptimisticMutationOptions<T>,
+): Promise<boolean> {
 	const { storageKey, rollback, request, onSuccess, errorMessage } = opts;
 
 	try {
@@ -50,7 +52,7 @@ export async function runOptimisticMutation<T = unknown>(opts: OptimisticMutatio
 				const data = (await res.json().catch(() => null)) as T | null;
 				if (data) onSuccess(data);
 			}
-			return;
+			return true;
 		}
 
 		rollback();
@@ -61,12 +63,14 @@ export async function runOptimisticMutation<T = unknown>(opts: OptimisticMutatio
 			(typeof body === 'object' && body && 'error' in body ? String((body as { error: string }).error) : null) ??
 			'Request failed';
 		showAppError(msg);
+		return false;
 	} catch {
 		queueOperation({
 			url: request.url,
 			method: request.method,
 			body: request.body,
 		});
+		return true;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Disable the "Cadastrar objetivo" button while `POST /api/goals` is in flight
- Show a spinner and server-rendered "Criando objetivo" copy during submission
- Wait for a successful API response before navigating to `/goals`
- Add `goal_submitting` i18n strings (pt-BR, en-US, es-ES)

## Test plan
- [ ] Open `/goals/new` while logged in
- [ ] Fill the form and click "Cadastrar objetivo"
- [ ] Button shows spinner + "Criando objetivo" and stays disabled until the request completes
- [ ] On success, redirect to `/goals` with the new goal
- [ ] On API error, button returns to "Cadastrar objetivo" and error modal appears


Made with [Cursor](https://cursor.com)