### PR TITLE
Astro PWA rewrite with monitoring worker and SES integration tests

### DIFF
--- a/frontend/.dev.vars.example
+++ b/frontend/.dev.vars.example
@@ -15,7 +15,7 @@ SNS_PLATFORM_ARN=
 # Web Push (VAPID) — generate with: npx web-push generate-vapid-keys
 VAPID_PUBLIC_KEY=BHQo40sM6T0s4mZVsqHJc05pPbVy8TYFhuSTUAY2nsqFNP3uMwKaBRlaf2pqdeyHWSfrHEm4i9sieIdXu7k21Xc
 VAPID_PRIVATE_KEY=
-VAPID_SUBJECT=mailto:domains@ambiente1.com.br
+VAPID_SUBJECT=mailto:domains@messages.ambiente1.com.br
 
 # Production secrets (Workers):
 # wrangler secret put AUTH_SECRET

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -29,9 +29,9 @@ COGNITO_DOMAIN = "sa-east-1qss34qx4b.auth.sa-east-1.amazoncognito.com"
 COGNITO_USER_POOL_ID = "sa-east-1_qSS34qX4b"
 COGNITO_CLIENT_ID = "21kjqv2t7i3j3fe38eqngl4bsi"
 AWS_REGION = "sa-east-1"
-SES_FROM_EMAIL = "domains@ambiente1.com.br"
+SES_FROM_EMAIL = "domains@messages.ambiente1.com.br"
 VAPID_PUBLIC_KEY = "BBCZlBnq4VxwJTkCL08C1zrafpvOSBTFMPwHXHlfAm3kTNadoR8WNTRfajZGdR6mrMIDvxRpBMlwJYbygssrMUE"
-VAPID_SUBJECT = "mailto:domains@ambiente1.com.br"
+VAPID_SUBJECT = "mailto:domains@messages.ambiente1.com.br"
 
 # Secrets (set in production with `wrangler secret put <NAME>`):
 # AUTH_SECRET, COGNITO_CLIENT_SECRET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, SNS_PLATFORM_ARN, VAPID_PRIVATE_KEY

--- a/monitoring/.dev.vars.example
+++ b/monitoring/.dev.vars.example
@@ -2,13 +2,15 @@
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=us-east-1
-SES_FROM_EMAIL=
-SNS_PLATFORM_ARN=
+SES_FROM_EMAIL=domains@messages.ambiente1.com.br
+
+# Integration tests (npm run test:integration)
+TEST_EMAIL=
 
 # Web Push (same keys as frontend)
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
-VAPID_SUBJECT=
+VAPID_SUBJECT=mailto:domains@messages.ambiente1.com.br
 
 # wrangler secret put VAPID_PRIVATE_KEY
 # wrangler secret put AWS_ACCESS_KEY_ID

--- a/monitoring/package-lock.json
+++ b/monitoring/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.758.0",
-        "@aws-sdk/client-sns": "^3.758.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
@@ -86,27 +85,6 @@
       "version": "3.1071.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1071.0.tgz",
       "integrity": "sha512-KVs3nUgIVRrNW68zJjje4Mr9X9FvmQSHJU0MoiIvfqPI17MB5YIH7XLWL3yKKBVDlvbnfQ5dc1W6haX08r9Ujg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.22",
-        "@aws-sdk/credential-provider-node": "^3.972.57",
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/core": "^3.24.6",
-        "@smithy/fetch-http-handler": "^5.4.6",
-        "@smithy/node-http-handler": "^4.7.6",
-        "@smithy/types": "^4.14.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1071.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1071.0.tgz",
-      "integrity": "sha512-/fgKJy/z0cOWyj0riUQ7HFurhW6tuRgjf9aVD5XVUZFh0Q6vg2x6Z9Fjnt3Ka3Ws8V8xgnoflK0aSl+P/V88pQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/monitoring/package.json
+++ b/monitoring/package.json
@@ -6,11 +6,11 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@aws-sdk/client-ses": "^3.758.0",
-    "@aws-sdk/client-sns": "^3.758.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {

--- a/monitoring/src/dispatch/push.ts
+++ b/monitoring/src/dispatch/push.ts
@@ -1,6 +1,4 @@
 import type { Env } from '../env';
-import { renderTemplate } from '../lib/render-template';
-import pushTemplate from '../templates/reminder-push';
 import { sendWebPush, type PushSubscriptionJSON } from '../web-push';
 
 export interface PushPayload {
@@ -11,57 +9,24 @@ export interface PushPayload {
 
 export async function sendPush(env: Env, userId: string, payload: PushPayload): Promise<void> {
 	const { results } = await env.DB.prepare(
-		`SELECT platform, sns_endpoint_arn, push_subscription FROM f2w_user_devices WHERE user_id = ?`,
+		`SELECT platform, push_subscription FROM f2w_user_devices WHERE user_id = ?`,
 	)
 		.bind(userId)
 		.all<{
 			platform: string;
-			sns_endpoint_arn: string;
 			push_subscription: string | null;
 		}>();
 
 	if (!results?.length) return;
 
 	for (const device of results) {
-		if (device.platform === 'web' && device.push_subscription) {
-			try {
-				const subscription = JSON.parse(device.push_subscription) as PushSubscriptionJSON;
-				await sendWebPush(env, subscription, payload);
-			} catch (err) {
-				console.error('Web push failed', err);
-			}
-			continue;
-		}
+		if (device.platform !== 'web' || !device.push_subscription) continue;
 
-		if (device.platform !== 'web' && device.sns_endpoint_arn && env.SNS_PLATFORM_ARN) {
-			await sendViaSns(env, device.sns_endpoint_arn, payload);
+		try {
+			const subscription = JSON.parse(device.push_subscription) as PushSubscriptionJSON;
+			await sendWebPush(env, subscription, payload);
+		} catch (err) {
+			console.error('Web push failed', err);
 		}
 	}
-}
-
-async function sendViaSns(env: Env, endpointArn: string, payload: PushPayload): Promise<void> {
-	if (!env.AWS_ACCESS_KEY_ID) return;
-
-	const { SNSClient, PublishCommand } = await import('@aws-sdk/client-sns');
-	const client = new SNSClient({
-		region: env.AWS_REGION,
-		credentials: {
-			accessKeyId: env.AWS_ACCESS_KEY_ID,
-			secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
-		},
-	});
-
-	const message = renderTemplate(JSON.stringify(pushTemplate), {
-		title: payload.title,
-		body: payload.body,
-		goalId: payload.goalId,
-	});
-
-	await client.send(
-		new PublishCommand({
-			TargetArn: endpointArn,
-			Message: message,
-			MessageStructure: 'json',
-		}),
-	);
 }

--- a/monitoring/src/env.ts
+++ b/monitoring/src/env.ts
@@ -4,7 +4,6 @@ export interface Env {
 	AWS_ACCESS_KEY_ID: string;
 	AWS_SECRET_ACCESS_KEY: string;
 	SES_FROM_EMAIL: string;
-	SNS_PLATFORM_ARN: string;
 	VAPID_PUBLIC_KEY: string;
 	VAPID_PRIVATE_KEY: string;
 	VAPID_SUBJECT: string;

--- a/monitoring/src/integration/aws-email.integration.test.ts
+++ b/monitoring/src/integration/aws-email.integration.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+	GetIdentityVerificationAttributesCommand,
+	GetSendQuotaCommand,
+	SESClient,
+} from '@aws-sdk/client-ses';
+import { sendEmail } from '../dispatch/email';
+import { loadIntegrationEnv, logConfigSummary } from '../test/integration-env';
+import { logAwsError } from '../test/log-aws-error';
+
+describe('AWS SES — email (integração real)', () => {
+	const { env, vars, testEmail } = loadIntegrationEnv();
+	const recipient = testEmail ?? env.SES_FROM_EMAIL;
+
+	beforeAll(() => {
+		logConfigSummary(vars);
+	});
+
+	it('credenciais AWS são aceitas pelo SES', async () => {
+		const client = new SESClient({
+			region: env.AWS_REGION,
+			credentials: {
+				accessKeyId: env.AWS_ACCESS_KEY_ID,
+				secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+			},
+		});
+
+		try {
+			const quota = await client.send(new GetSendQuotaCommand({}));
+			console.log('\n[SES] Credenciais válidas. Quota diária:', quota.Max24HourSend);
+			console.log('[SES] Enviados nas últimas 24h:', quota.SentLast24Hours);
+		} catch (err) {
+			logAwsError('GetSendQuota — credenciais ou região inválidas', err);
+			throw err;
+		}
+	});
+
+	it('SES_FROM_EMAIL está verificado no SES', async () => {
+		if (!env.SES_FROM_EMAIL) {
+			console.error('\n[SES] SES_FROM_EMAIL não definido em .dev.vars');
+			expect.fail('Defina SES_FROM_EMAIL em .dev.vars');
+		}
+
+		const client = new SESClient({
+			region: env.AWS_REGION,
+			credentials: {
+				accessKeyId: env.AWS_ACCESS_KEY_ID,
+				secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+			},
+		});
+
+		const domain = env.SES_FROM_EMAIL.split('@')[1];
+
+		try {
+			const result = await client.send(
+				new GetIdentityVerificationAttributesCommand({
+					Identities: [env.SES_FROM_EMAIL, domain],
+				}),
+			);
+
+			const emailStatus =
+				result.VerificationAttributes?.[env.SES_FROM_EMAIL]?.VerificationStatus;
+			const domainStatus = result.VerificationAttributes?.[domain]?.VerificationStatus;
+			console.log(`\n[SES] Status de ${env.SES_FROM_EMAIL}: ${emailStatus ?? 'não encontrado'}`);
+			console.log(`[SES] Status do domínio ${domain}: ${domainStatus ?? 'não encontrado'}`);
+
+			const verified = emailStatus === 'Success' || domainStatus === 'Success';
+			if (!verified) {
+				console.error(
+					`[SES] Remetente não verificado. Verifique ${domain} ou ${env.SES_FROM_EMAIL} no console SES → Verified identities`,
+				);
+			}
+
+			expect(verified).toBe(true);
+		} catch (err) {
+			logAwsError(`GetIdentityVerificationAttributes — ${env.SES_FROM_EMAIL}`, err);
+			throw err;
+		}
+	});
+
+	it('envia email de teste real via SES', async () => {
+		if (!env.SES_FROM_EMAIL) {
+			expect.fail('Defina SES_FROM_EMAIL em .dev.vars');
+		}
+		if (!recipient) {
+			expect.fail('Defina TEST_EMAIL ou SES_FROM_EMAIL em .dev.vars');
+		}
+
+		console.log(`\n[SES] Enviando email de teste: ${env.SES_FROM_EMAIL} → ${recipient}`);
+
+		try {
+			await sendEmail(
+				env,
+				recipient,
+				'[52weekchallenge] Teste de integração SES',
+				`<p>Email de teste enviado em ${new Date().toISOString()}.</p><p>Se você recebeu, SES está configurado corretamente.</p>`,
+			);
+			console.log('[SES] Email enviado com sucesso.');
+		} catch (err) {
+			logAwsError(`SendEmail — ${env.SES_FROM_EMAIL} → ${recipient}`, err);
+			throw err;
+		}
+	});
+});

--- a/monitoring/src/scheduled/process-due-today.test.ts
+++ b/monitoring/src/scheduled/process-due-today.test.ts
@@ -21,7 +21,6 @@ function createEnv(options: {
 	existingDedup?: boolean;
 	devices?: Array<{
 		platform: string;
-		sns_endpoint_arn: string;
 		push_subscription: string | null;
 	}>;
 }): Env {
@@ -54,7 +53,6 @@ function createEnv(options: {
 		AWS_ACCESS_KEY_ID: 'key',
 		AWS_SECRET_ACCESS_KEY: 'secret',
 		SES_FROM_EMAIL: 'noreply@example.com',
-		SNS_PLATFORM_ARN: 'arn:aws:sns:example',
 		VAPID_PUBLIC_KEY: 'public',
 		VAPID_PRIVATE_KEY: 'private',
 		VAPID_SUBJECT: 'mailto:test@example.com',
@@ -84,7 +82,6 @@ describe('processDueToday', () => {
 			devices: [
 				{
 					platform: 'web',
-					sns_endpoint_arn: '',
 					push_subscription: JSON.stringify({ endpoint: 'https://push.test', keys: {} }),
 				},
 			],

--- a/monitoring/src/test/integration-env.ts
+++ b/monitoring/src/test/integration-env.ts
@@ -1,0 +1,52 @@
+import type { Env } from '../env';
+import { loadDevVars, requireDevVar, validateAwsRegion } from './load-dev-vars';
+
+export interface IntegrationEnv {
+	vars: Record<string, string>;
+	env: Env;
+	testEmail: string | null;
+}
+
+export function loadIntegrationEnv(): IntegrationEnv {
+	const vars = loadDevVars();
+
+	const env: Env = {
+		DB: {} as D1Database,
+		AWS_REGION: requireDevVar(vars, 'AWS_REGION'),
+		AWS_ACCESS_KEY_ID: requireDevVar(vars, 'AWS_ACCESS_KEY_ID'),
+		AWS_SECRET_ACCESS_KEY: requireDevVar(vars, 'AWS_SECRET_ACCESS_KEY'),
+		SES_FROM_EMAIL: vars.SES_FROM_EMAIL?.trim() ?? '',
+		VAPID_PUBLIC_KEY: vars.VAPID_PUBLIC_KEY?.trim() ?? '',
+		VAPID_PRIVATE_KEY: vars.VAPID_PRIVATE_KEY?.trim() ?? '',
+		VAPID_SUBJECT: vars.VAPID_SUBJECT?.trim() ?? '',
+	};
+
+	return {
+		vars,
+		env,
+		testEmail: vars.TEST_EMAIL?.trim() || null,
+	};
+}
+
+export function logConfigSummary(vars: Record<string, string>): void {
+	const mask = (value: string | undefined) => {
+		if (!value) return '(vazio)';
+		if (value.length <= 8) return '***';
+		return `${value.slice(0, 4)}…${value.slice(-4)}`;
+	};
+
+	console.log('\n[SES] Configuração carregada de .dev.vars:');
+	console.log(`  AWS_REGION:            ${vars.AWS_REGION || '(vazio)'}`);
+	console.log(`  AWS_ACCESS_KEY_ID:     ${mask(vars.AWS_ACCESS_KEY_ID)}`);
+	console.log(`  AWS_SECRET_ACCESS_KEY: ${vars.AWS_SECRET_ACCESS_KEY ? '(definido)' : '(vazio)'}`);
+	console.log(`  SES_FROM_EMAIL:        ${vars.SES_FROM_EMAIL || '(vazio)'}`);
+	console.log(`  TEST_EMAIL:            ${vars.TEST_EMAIL || '(vazio — usa SES_FROM_EMAIL)'}`);
+
+	const regionIssues = validateAwsRegion(vars.AWS_REGION ?? '');
+	if (regionIssues.length) {
+		console.warn('\n  ⚠ Problemas na região:');
+		for (const issue of regionIssues) {
+			console.warn(`    • ${issue}`);
+		}
+	}
+}

--- a/monitoring/src/test/load-dev-vars.ts
+++ b/monitoring/src/test/load-dev-vars.ts
@@ -1,0 +1,80 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_DEV_VARS_PATH = resolve(__dirname, '../../.dev.vars');
+
+function trimQuotes(value: string): string {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+export function loadDevVars(filePath = DEFAULT_DEV_VARS_PATH): Record<string, string> {
+	if (!existsSync(filePath)) {
+		throw new Error(
+			`Arquivo .dev.vars não encontrado em ${filePath}. Copie .dev.vars.example e preencha as credenciais.`,
+		);
+	}
+
+	const vars: Record<string, string> = {};
+
+	for (const rawLine of readFileSync(filePath, 'utf8').split('\n')) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith('#') || !line.includes('=')) continue;
+
+		const eqIndex = line.indexOf('=');
+		const key = line.slice(0, eqIndex).trim();
+		const value = trimQuotes(line.slice(eqIndex + 1));
+		if (key) vars[key] = value;
+	}
+
+	return vars;
+}
+
+const VALID_AWS_REGIONS = new Set([
+	'us-east-1',
+	'us-east-2',
+	'us-west-1',
+	'us-west-2',
+	'sa-east-1',
+	'eu-west-1',
+	'eu-west-2',
+	'eu-central-1',
+	'ap-southeast-1',
+	'ap-southeast-2',
+	'ap-northeast-1',
+]);
+
+export function validateAwsRegion(region: string): string[] {
+	const issues: string[] = [];
+
+	if (!region) {
+		issues.push('AWS_REGION está vazio');
+		return issues;
+	}
+
+	if (region === 'us-sa-1') {
+		issues.push('AWS_REGION=us-sa-1 parece incorreto — use sa-east-1 (São Paulo)');
+	}
+
+	if (!VALID_AWS_REGIONS.has(region) && !/^[\w-]+-\w+-\d+$/.test(region)) {
+		issues.push(`AWS_REGION "${region}" não parece um código de região AWS válido`);
+	}
+
+	return issues;
+}
+
+export function requireDevVar(vars: Record<string, string>, key: string): string {
+	const value = vars[key]?.trim();
+	if (!value) {
+		throw new Error(`Variável obrigatória ausente em .dev.vars: ${key}`);
+	}
+	return value;
+}

--- a/monitoring/src/test/log-aws-error.ts
+++ b/monitoring/src/test/log-aws-error.ts
@@ -1,0 +1,73 @@
+export interface AwsSdkError extends Error {
+	name: string;
+	$metadata?: {
+		httpStatusCode?: number;
+		requestId?: string;
+		attempts?: number;
+		totalRetryDelay?: number;
+	};
+	Code?: string;
+	Type?: string;
+	Detail?: string;
+}
+
+export function isAwsSdkError(err: unknown): err is AwsSdkError {
+	return err instanceof Error && 'name' in err;
+}
+
+export function logAwsError(context: string, err: unknown): void {
+	console.error(`\n[AWS ERROR] ${context}`);
+	console.error('─'.repeat(60));
+
+	if (!isAwsSdkError(err)) {
+		console.error('Erro desconhecido:', err);
+		return;
+	}
+
+	console.error(`Tipo:    ${err.name}`);
+	if (err.Code) console.error(`Code:    ${err.Code}`);
+	console.error(`Mensagem: ${err.message}`);
+	if (err.Type) console.error(`Type:    ${err.Type}`);
+	if (err.Detail) console.error(`Detail:  ${err.Detail}`);
+
+	if (err.$metadata) {
+		const { httpStatusCode, requestId, attempts } = err.$metadata;
+		if (httpStatusCode) console.error(`HTTP:    ${httpStatusCode}`);
+		if (requestId) console.error(`Request: ${requestId}`);
+		if (attempts) console.error(`Tentativas: ${attempts}`);
+	}
+
+	const hints = getFixHints(err);
+	if (hints.length) {
+		console.error('\nPossíveis correções:');
+		for (const hint of hints) {
+			console.error(`  • ${hint}`);
+		}
+	}
+
+	console.error('─'.repeat(60));
+}
+
+function getFixHints(err: AwsSdkError): string[] {
+	const hints: string[] = [];
+	const text = `${err.name} ${err.Code ?? ''} ${err.message}`.toLowerCase();
+
+	if (text.includes('invalidclienttokenid') || text.includes('signature')) {
+		hints.push('Verifique AWS_ACCESS_KEY_ID e AWS_SECRET_ACCESS_KEY em .dev.vars');
+	}
+	if (text.includes('unrecognizedclientexception') || text.includes('invalid region')) {
+		hints.push('AWS_REGION inválida — use ex.: us-east-1 ou sa-east-1 (não us-sa-1)');
+	}
+	if (text.includes('accessdenied') || text.includes('not authorized')) {
+		hints.push('A IAM user/role precisa das permissões corretas (ses:SendEmail, ses:GetSendQuota, etc.)');
+	}
+	if (text.includes('messagerejected') || text.includes('email address is not verified')) {
+		hints.push('No sandbox SES, remetente e destinatário precisam estar verificados no console AWS');
+		hints.push('Verifique SES_FROM_EMAIL e TEST_EMAIL no console SES → Verified identities');
+	}
+	if (text.includes('enotfound') || text.includes('not found') && text.includes('amazonaws')) {
+		hints.push(`Região AWS inválida ou endpoint inexistente — confira AWS_REGION (atual pode estar errada, ex.: us-sa-1 → sa-east-1)`);
+	}
+
+	return hints;
+}

--- a/monitoring/vitest.integration.config.ts
+++ b/monitoring/vitest.integration.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['src/**/*.test.ts'],
-		exclude: ['src/**/*.integration.test.ts'],
+		include: ['src/**/*.integration.test.ts'],
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
 	},
 });

--- a/monitoring/wrangler.toml
+++ b/monitoring/wrangler.toml
@@ -22,9 +22,10 @@ database_name = "domain-monitor"
 database_id = "8b21eb9b-08fb-47e5-889c-cd2a68181e0b"
 
 [vars]
-AWS_REGION = "us-east-1"
+AWS_REGION = "sa-east-1"
+SES_FROM_EMAIL = "domains@messages.ambiente1.com.br"
 VAPID_PUBLIC_KEY = "BBCZlBnq4VxwJTkCL08C1zrafpvOSBTFMPwHXHlfAm3kTNadoR8WNTRfajZGdR6mrMIDvxRpBMlwJYbygssrMUE"
-VAPID_SUBJECT = "mailto:domains@ambiente1.com.br"
+VAPID_SUBJECT = "mailto:domains@messages.ambiente1.com.br"
 
-# Secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, SES_FROM_EMAIL, SNS_PLATFORM_ARN, VAPID_PRIVATE_KEY
+# Secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, SES_FROM_EMAIL, VAPID_PRIVATE_KEY
 


### PR DESCRIPTION
## Summary
- Replace the legacy Quasar app with an Astro PWA on Cloudflare Workers (auth, goals, deposits, notifications, Web Push)
- Add a scheduled monitoring worker that sends due-today savings reminders via SES email and web push
- Add real AWS SES integration tests (`npm run test:integration`) that validate credentials, verified domain, and actual email delivery without mocks
- Remove SNS mobile push dispatch and align `SES_FROM_EMAIL` to the verified `messages.ambiente1.com.br` domain across frontend and monitoring

## Test plan
- [ ] `cd frontend && npm test`
- [ ] `cd monitoring && npm test`
- [ ] `cd monitoring && npm run test:integration` (requires `.dev.vars` with valid AWS SES credentials)
- [ ] Create a goal and confirm due-today reminder email is sent from `domains@messages.ambiente1.com.br`
- [ ] Verify web push reminders still work for registered devices


Made with [Cursor](https://cursor.com)